### PR TITLE
PRO-4660: Fix Buy now z-index

### DIFF
--- a/modules/theme/views/card.html
+++ b/modules/theme/views/card.html
@@ -44,7 +44,7 @@
           {{ buttons.primary(
             __t('app:productBuyNowUrl'), 
             href=item.buyNowUrl, 
-            { cls:'z-10' }
+            { cls:'z-[1]' }
           ) }}
         {%- endif -%}
       </div>


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary
When trying to add Content on the Products page, the context menu from Add Content is covered from the Buy Now button in an existing product card, see below under **Other information:** section:

The fix is that Buy Now button now has z-index of just 1 (`z-[1]`), instead of z-index of 10 (`z-10`)

## What are the specific steps to test this change?

Widget menu should not overflow the Buy Now button. 

Before the bug fix:
![image](https://github.com/apostrophecms/starter-kit-ecommerce/assets/92857650/3830fb5a-9277-49fb-98c6-2673bff501ef)

After the bug fix:
![image](https://github.com/apostrophecms/starter-kit-ecommerce/assets/92857650/c4d26c6d-18c4-451f-a7a4-39216f2f4401)

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

